### PR TITLE
Faster analog

### DIFF
--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -40,7 +40,7 @@
 #define CONTROL_ZERO_BITS 389   /* Bits required for correct control reg size */
 #define TOTAL_REGISTER_SIZE 76
 #define LATCH_DELAY 1
-#define CONTROL_WRITE_COUNT 2
+#define CONTROL_WRITE_COUNT 1
 #define CONTROL_MODE_ON 1
 #define CONTROL_MODE_OFF 0
 

--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -517,12 +517,12 @@ void TLC5955::setBuffer(uint8_t bit)
 {
   bitWrite(_buffer, _buffer_count, bit);
   _buffer_count--;
-  SPI.beginTransaction(mSettings);
   if (_buffer_count == -1)
   {
+    SPI.beginTransaction(mSettings);
     SPI.transfer(_buffer);
     _buffer_count = 7;
     _buffer = 0;
+    SPI.endTransaction();
   }
-  SPI.endTransaction();
 }

--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -449,6 +449,7 @@ void TLC5955::getDotCorrection(uint8_t* dotCorrection)
 // Update the Control Register (changes settings)
 void TLC5955::updateControl()
 {
+  ssize_t a;
   for (int8_t repeatCtr = 0; repeatCtr < CONTROL_WRITE_COUNT; repeatCtr++)
   {
     for (int8_t chip = _tlc_count - 1; chip >= 0; chip--)
@@ -457,24 +458,30 @@ void TLC5955::updateControl()
       setControlModeBit(CONTROL_MODE_ON);
 
       // Add CONTROL_ZERO_BITS blank bits to get to correct position for DC/FC
-      for (int16_t a = 0; a < CONTROL_ZERO_BITS; a++)
+
+      SPI.beginTransaction(mSettings);
+      for (a = 0; a + 16 < CONTROL_ZERO_BITS; a = a + 16)
+          SPI.transfer16(0);
+      SPI.endTransaction();
+
+      for (a; a < CONTROL_ZERO_BITS; a++)
         setBuffer(0);
       // 5-bit Function Data
-      for (int8_t a = FC_BITS - 1; a >= 0; a--)
+      for (a = FC_BITS - 1; a >= 0; a--)
         setBuffer((_function_data & (1 << a)));
       // Brightness Control Data
-      for (int8_t a = BC_BITS - 1; a >= 0; a--)
+      for (a = BC_BITS - 1; a >= 0; a--)
         setBuffer((_BC[2] & (1 << a)));
-      for (int8_t a = BC_BITS - 1; a >= 0; a--)
+      for (a = BC_BITS - 1; a >= 0; a--)
         setBuffer((_BC[1] & (1 << a)));
-      for (int8_t a = BC_BITS - 1; a >= 0; a--)
+      for (a = BC_BITS - 1; a >= 0; a--)
         setBuffer((_BC[0] & (1 << a)));
       // Maximum Current Data
-      for (int8_t a = MC_BITS - 1; a >= 0; a--)
+      for (a = MC_BITS - 1; a >= 0; a--)
         setBuffer((_MC[2] & (1 << a)));
-      for (int8_t a = MC_BITS - 1; a >= 0; a--)
+      for (a = MC_BITS - 1; a >= 0; a--)
         setBuffer((_MC[1] & (1 << a)));
-      for (int8_t a = MC_BITS - 1; a >= 0; a--)
+      for (a = MC_BITS - 1; a >= 0; a--)
         setBuffer((_MC[0] & (1 << a)));
 
       // Dot Correction Data

--- a/TLC5955.h
+++ b/TLC5955.h
@@ -35,6 +35,7 @@
 
 #include <stdint.h>
 #include <SPI.h>
+#define TLC5955_COLOR_CHANNEL_COUNT 3
 
 class TLC5955
 {
@@ -86,7 +87,7 @@ void setGsclkFreq(uint32_t new_gsclk_frequency);
 uint32_t getGsclkFreq();
 
 static const uint8_t _tlc_count; // This
-static const uint8_t COLOR_CHANNEL_COUNT = 3;
+static const uint8_t COLOR_CHANNEL_COUNT = TLC5955_COLOR_CHANNEL_COUNT;
 static const uint8_t LEDS_PER_CHIP = 16;
 static bool enforce_max_current;
 static double max_current_amps;

--- a/TLC5955.h
+++ b/TLC5955.h
@@ -72,8 +72,6 @@ void setRgbPinOrder(uint8_t rPos, uint8_t grPos, uint8_t bPos);
 void setPinOrderSingle(uint16_t channel, uint8_t color_channel_index, uint8_t position);
 void setRgbPinOrderSingle(uint16_t channel, uint8_t rPos, uint8_t grPos, uint8_t bPos);
 
-/* Sending data to device (Updating, flushing, latching) */
-void setBuffer(uint8_t bit);
 void setControlModeBit(bool isControlMode);
 void flushBuffer();
 // Returns 0 for success, other for failure
@@ -99,6 +97,8 @@ static uint16_t _grayscale_data[][LEDS_PER_CHIP][COLOR_CHANNEL_COUNT];
 uint8_t rgb_order_default[3] = {0, 1, 2};
 
 private:
+  /* Sending data to device (Updating, flushing, latching) */
+  void setBuffer(uint8_t bit);
   uint8_t _gslat;
   uint8_t _spi_mosi;
   uint8_t _spi_clk;


### PR DESCRIPTION
The following changes get us from 175 ms to change the analog controls to 41 ms.

I want to reduce an other 10 ms to get to the same limit as that of setting the grayscale data.