### PR TITLE
Disable the grayscale clock on init allow the user to configure the

### DIFF
--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -65,7 +65,9 @@ void TLC5955::init(uint8_t gslat, uint8_t spi_mosi, uint8_t spi_clk, uint8_t gsc
 
   // set up gsclk
   pinMode(_gsclk, OUTPUT);
-  setGsclkFreq(gsclk_frequency);
+  // Do not write the gsclk frequency here. The system isn't fully setup
+  // and there will be a flash of white light
+  // setGsclkFreq(gsclk_frequency);
 
   // Set default color channel indicies
   setRgbPinOrder(rgb_order_default[0], rgb_order_default[1], rgb_order_default[2]);


### PR DESCRIPTION
system